### PR TITLE
Support Megatag2.  But off for default until we test on robot.

### DIFF
--- a/elastic-layout-mochi.json
+++ b/elastic-layout-mochi.json
@@ -251,7 +251,7 @@
           },
           {
             "title": "TargetList",
-            "x": 640.0,
+            "x": 768.0,
             "y": 0.0,
             "width": 256.0,
             "height": 128.0,
@@ -397,7 +397,7 @@
           },
           {
             "title": "Camera1 Health",
-            "x": 896.0,
+            "x": 1024.0,
             "y": 0.0,
             "width": 256.0,
             "height": 128.0,
@@ -411,7 +411,7 @@
           },
           {
             "title": "Camera2 Health",
-            "x": 896.0,
+            "x": 1024.0,
             "y": 128.0,
             "width": 256.0,
             "height": 128.0,
@@ -421,6 +421,23 @@
               "period": 0.06,
               "data_type": "string",
               "show_submit_button": false
+            }
+          },
+          {
+            "title": "Mt2",
+            "x": 640.0,
+            "y": 0.0,
+            "width": 128.0,
+            "height": 128.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/BasicInfo/IsMt2",
+              "period": 0.06,
+              "data_type": "boolean",
+              "true_color": 4283215696,
+              "false_color": 4278190080,
+              "true_icon": "None",
+              "false_icon": "None"
             }
           }
         ]

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -46,8 +46,8 @@ public final class Constants {
         public static final int kLeftArmMotorID = 20;
         public static final int kRightArmMotorID = 21;
 
-        /** Max angle (degrees) — lowered/deployed position. 
-         * Measured on hardware: 2/23/2026 
+        /** Max angle (degrees) — lowered/deployed position.
+         * Measured on hardware: 2/23/2026
         */
         public static final double kMaxArmAngle = 160;
 
@@ -219,6 +219,17 @@ public final class Constants {
     public static final class VisionConstants {
         /** Default value for the VisionEnabled toggle (true = vision on). */
         public static final boolean kVisionEnabledDefault = true;
+
+        /** When false, MegaTag2 pose estimates are never requested or used. */
+        // $TODO - Enable after testing
+        public static final boolean kSupportMegatag2 = false;
+
+        /**
+         * Distance advantage (meters) given to MegaTag2 when comparing estimates.
+         * MT2 is preferred over MT1 if its avgTagDist is within this margin of MT1's,
+         * because gyro-fused rotation makes the estimate more reliable at similar range.
+         */
+        public static final double kMt2DistanceAdvantageMeter = 0.5;
     }
 
     /**

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -72,6 +72,7 @@ public class Robot extends TimedRobot {
         m_robotContainer.m_simWrapper.robotPeriodic();
     }
 
+    m_robotContainer.m_multiCamlimelight.setRobotOrientation();
     m_robotContainer.m_multiCamlimelight.periodic();
 
     Optional<Pose2d> showVisPose = m_robotContainer.basicInfoDashboard.isVisionEnabled() ?

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -252,6 +252,7 @@ public class RobotContainer {
             m_configInterface,
             drivetrain::samplePoseAt,
             drivetrain::addVisionMeasurement,
+            () -> drivetrain.getState().Pose.getRotation().getDegrees(),
             basicInfoDashboard,
             m_visionKalmanFilter,
             m_motionlessTracker);

--- a/src/main/java/frc/robot/sim/visionproducers/LimelightTablePublisher.java
+++ b/src/main/java/frc/robot/sim/visionproducers/LimelightTablePublisher.java
@@ -61,9 +61,12 @@ public class LimelightTablePublisher {
         // Bot pose arrays for pose estimation
         table.getEntry("botpose_wpiblue").setDoubleArray(data.botposeWpiBlue);
         table.getEntry("botpose_wpired").setDoubleArray(data.botposeWpiRed);
+
         // Also publish as MegaTag2 format (same data for simulation purposes)
-        //table.getEntry("botpose_orb_wpiblue").setDoubleArray(data.botposeWpiBlue);
-        //table.getEntry("botpose_orb_wpired").setDoubleArray(data.botposeWpiRed);
+        if (VisionSimConstants.Vision.kPublishMt2Poses) {
+            table.getEntry("botpose_orb_wpiblue").setDoubleArray(data.botposeWpiBlue);
+            table.getEntry("botpose_orb_wpired").setDoubleArray(data.botposeWpiRed);
+        };
 
         // Heartbeat — increments forever so VisionHeartBeat can detect the camera is alive
         table.getEntry("hb").setDouble(m_heartbeat++);

--- a/src/main/java/frc/robot/sim/visionproducers/VisionSimConstants.java
+++ b/src/main/java/frc/robot/sim/visionproducers/VisionSimConstants.java
@@ -16,6 +16,9 @@ public class VisionSimConstants {
         // with simulated subsystems.
         public static final boolean kForceSimWrapperOff = false;
 
+        // Whether to also publish MegaTag2 pose entries (botpose_orb_wpiblue / botpose_orb_wpired).
+        public static final boolean kPublishMt2Poses = true;
+
         // Camera name (must match PhotonVision camera name)
         public static final String kPhotonCameraNamePrefix = "photon-";
 

--- a/src/main/java/frc/robot/util/MathUtils.java
+++ b/src/main/java/frc/robot/util/MathUtils.java
@@ -1,0 +1,15 @@
+package frc.robot.util;
+
+public final class MathUtils {
+    private MathUtils() {}
+
+    /** Returns true if {@code a} and {@code b} differ by no more than {@code tol}. */
+    public static boolean approxEqual(double a, double b, double tol) {
+        return Math.abs(a - b) <= tol;
+    }
+
+    /** Returns true if {@code a} and {@code b} differ by no more than 1e-9. */
+    public static boolean approxEqual(double a, double b) {
+        return approxEqual(a, b, 1e-9);
+    }
+}

--- a/src/main/java/frc/robot/visutils/BasicInfoDashboard.java
+++ b/src/main/java/frc/robot/visutils/BasicInfoDashboard.java
@@ -51,6 +51,7 @@ public class BasicInfoDashboard {
     private final DoublePublisher m_visionConfidence = m_basicInfoTable.getDoubleTopic("VisionConfidence").publish();
     private final BooleanPublisher m_oneLocked = m_basicInfoTable.getBooleanTopic("OneLocked").publish();
     private final BooleanPublisher m_multiLocked = m_basicInfoTable.getBooleanTopic("MultiLocked").publish();
+    private final BooleanPublisher m_isMt2 = m_basicInfoTable.getBooleanTopic("IsMt2").publish();
     private final DoublePublisher m_visionTx = m_basicInfoTable.getDoubleTopic("VisionTx").publish();
     private final StringPublisher m_targetList = m_basicInfoTable.getStringTopic("TargetList").publish();
     private final DoublePublisher m_visErrorCentimeters = m_basicInfoTable.getDoubleTopic("VisErrorCentimeters").publish();
@@ -75,6 +76,7 @@ public class BasicInfoDashboard {
     private DoubleSupplier m_visionConfidenceSupplier = null;
     private BooleanSupplier m_hasTargetLockSupplier = null;
     private BooleanSupplier m_hasMultiTagLockSupplier = null;
+    private BooleanSupplier m_isLatestMt2Supplier = null;
     private DoubleSupplier m_txSupplier = null;
     private Supplier<List<Integer>> m_targetListSupplier = null;
     private Supplier<VisionKalmanFilter> m_visionKalmanSupplier = null;
@@ -104,6 +106,8 @@ public class BasicInfoDashboard {
     private final Debouncer m_oneLockedDebouncer =
         new Debouncer(kLockedDebounceSeconds, Debouncer.DebounceType.kFalling);
     private final Debouncer m_multiLockedDebouncer =
+        new Debouncer(kLockedDebounceSeconds, Debouncer.DebounceType.kFalling);
+    private final Debouncer m_isMt2Debouncer =
         new Debouncer(kLockedDebounceSeconds, Debouncer.DebounceType.kFalling);
     private final Debouncer m_targetListDebouncer =
         new Debouncer(kLockedDebounceSeconds, Debouncer.DebounceType.kFalling);
@@ -162,6 +166,7 @@ public class BasicInfoDashboard {
      * @param confidenceSupplier         A DoubleSupplier returning confidence 0-100
      * @param hasTargetLockSupplier      A BooleanSupplier returning true if any camera has a target lock
      * @param hasMultiTagLockSupplier    A BooleanSupplier returning true if any camera has 2+ targets locked
+     * @param isLatestMt2Supplier        A BooleanSupplier returning true if the best camera's latest estimate used MegaTag2
      * @param txSupplier                 A DoubleSupplier returning tx in degrees
      * @param targetListSupplier         A Supplier returning comma-separated tag IDs
      * @param visErrorAtSnapTimeSupplier A Supplier returning the vision error at image-capture time
@@ -172,6 +177,7 @@ public class BasicInfoDashboard {
             DoubleSupplier confidenceSupplier,
             BooleanSupplier hasTargetLockSupplier,
             BooleanSupplier hasMultiTagLockSupplier,
+            BooleanSupplier isLatestMt2Supplier,
             DoubleSupplier txSupplier,
             Supplier<List<Integer>> targetListSupplier,
             Supplier<Optional<Transform2d>> visErrorAtSnapTimeSupplier,
@@ -180,6 +186,7 @@ public class BasicInfoDashboard {
         m_visionConfidenceSupplier = confidenceSupplier;
         m_hasTargetLockSupplier = hasTargetLockSupplier;
         m_hasMultiTagLockSupplier = hasMultiTagLockSupplier;
+        m_isLatestMt2Supplier = isLatestMt2Supplier;
         m_txSupplier = txSupplier;
         m_targetListSupplier = targetListSupplier;
         m_visErrorAtSnapTimeSupplier = visErrorAtSnapTimeSupplier;
@@ -268,6 +275,10 @@ public class BasicInfoDashboard {
         if (m_hasMultiTagLockSupplier != null) {
             boolean hasMultiTagLock = m_hasMultiTagLockSupplier.getAsBoolean();
             m_multiLocked.set(m_multiLockedDebouncer.calculate(hasMultiTagLock));
+        }
+        if (m_isLatestMt2Supplier != null) {
+            boolean isLatestMt2 = m_isLatestMt2Supplier.getAsBoolean();
+            m_isMt2.set(m_isMt2Debouncer.calculate(isLatestMt2));
         }
         if (m_txSupplier != null) {
             m_visionTx.set(m_txSupplier.getAsDouble());

--- a/src/main/java/frc/robot/visutils/CamOdometryInterface.java
+++ b/src/main/java/frc/robot/visutils/CamOdometryInterface.java
@@ -42,6 +42,11 @@ public interface CamOdometryInterface {
     boolean hasMultiTagLock();
 
     /**
+     * Returns true if the latest pose estimate from the best-locked camera used MegaTag2.
+     */
+    boolean isLatestMt2();
+
+    /**
      * Gets the AprilTag ID locked onto by the PRIMARY camera, or -1 if none.
      * Used to determine which tag the robot is aligned to for turning.
      */
@@ -52,6 +57,16 @@ public interface CamOdometryInterface {
      * Returns 0 if no target is locked. Used to determine rotation error for alignment.
      */
     double getPrimaryTagTx();
+
+    /**
+     * Pushes the robot's current heading to the Limelight for MegaTag2 and flushes.
+     */
+    void setRobotOrientation();
+
+    /**
+     * Pushes the robot's current heading to the Limelight for MegaTag2 without flushing.
+     */
+    void setRobotOrientation_NoFlush();
 
     /**
      * Periodic update; should be called from robot periodic.

--- a/src/main/java/frc/robot/visutils/MultiCamOdometry.java
+++ b/src/main/java/frc/robot/visutils/MultiCamOdometry.java
@@ -2,6 +2,7 @@ package frc.robot.visutils;
 
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Transform2d;
+import frc.robot.LimelightHelpers;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -46,6 +47,21 @@ public class MultiCamOdometry implements CamOdometryInterface {
      *   score that has a target lock.  We also track the FIRST camera
      *   (in order) that has a target lock.
      */
+    @Override
+    public void setRobotOrientation() {
+        for (CamOdometryInterface cam : m_cameras) {
+            cam.setRobotOrientation_NoFlush();
+        }
+        LimelightHelpers.Flush();
+    }
+
+    @Override
+    public void setRobotOrientation_NoFlush() {
+        for (CamOdometryInterface cam : m_cameras) {
+            cam.setRobotOrientation_NoFlush();
+        }
+    }
+
     @Override
     public void periodic() {
         m_perCycleState.reset();
@@ -118,6 +134,14 @@ public class MultiCamOdometry implements CamOdometryInterface {
     @Override
     public boolean hasMultiTagLock() {
         return m_perCycleState.hasMultiTagLock;
+    }
+
+    @Override
+    public boolean isLatestMt2() {
+        if (m_perCycleState.bestLockedCam.isPresent()) {
+            return m_perCycleState.bestLockedCam.get().isLatestMt2();
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/frc/robot/visutils/MultiCamOdometryFactory.java
+++ b/src/main/java/frc/robot/visutils/MultiCamOdometryFactory.java
@@ -4,9 +4,11 @@ import edu.wpi.first.math.geometry.Pose2d;
 import frc.robot.botconfig.BotConfigInterface;
 import frc.robot.botconfig.BotConfigInterface.CameraInfo;
 import frc.robot.sim.visionproducers.VisionSimInterface;
+import frc.robot.Constants.VisionConstants;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.DoubleSupplier;
 import java.util.function.Function;
 
 /** Factory for creating and wiring up a {@link MultiCamOdometry} instance. */
@@ -22,6 +24,8 @@ public class MultiCamOdometryFactory {
      * @param poseSampler        Samples the drivetrain's historical pose at a given timestamp
      *                           (e.g. {@code drivetrain::samplePoseAt})
      * @param poseConsumer       Consumer for vision pose estimates (e.g. {@code drivetrain::addVisionMeasurement})
+     * @param yawDegreesSupplier Supplies the robot's current heading in degrees (WPILib blue-alliance
+     *                           frame) for MegaTag2 orientation updates
      * @param basicInfoDashboard Dashboard to receive vision confidence/status updates
      * @param visionKalmanFilter Kalman filter for stationary vision estimation
      * @param motionlessTracker  Tracks whether the robot is motionless
@@ -31,6 +35,7 @@ public class MultiCamOdometryFactory {
             BotConfigInterface configInterface,
             Function<Double, Optional<Pose2d>> poseSampler,
             VisionSimInterface.EstimateConsumer poseConsumer,
+            DoubleSupplier yawDegreesSupplier,
             BasicInfoDashboard basicInfoDashboard,
             VisionKalmanFilter visionKalmanFilter,
             MotionlessTracker motionlessTracker) {
@@ -41,7 +46,9 @@ public class MultiCamOdometryFactory {
                 camInfo.cameraName,
                 camInfo.robotToCam,
                 poseConsumer,
-                poseSampler));
+                poseSampler,
+                yawDegreesSupplier,
+                VisionConstants.kSupportMegatag2));
         }
 
         CamOdometryInterface multiCam = new MultiCamOdometry(cameras);
@@ -55,6 +62,7 @@ public class MultiCamOdometryFactory {
             multiCam::getConfidenceScore,
             multiCam::hasTargetLock,
             multiCam::hasMultiTagLock,
+            multiCam::isLatestMt2,
             multiCam::getPrimaryTagTx,
             multiCam::getVisibleTagIds,
             multiCam::getVisionErrorAtSnapTime,

--- a/src/main/java/frc/robot/visutils/SingleCamOdometry.java
+++ b/src/main/java/frc/robot/visutils/SingleCamOdometry.java
@@ -11,11 +11,14 @@ import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import com.ctre.phoenix6.Utils;
+import frc.robot.Constants.VisionConstants;
 import frc.robot.LimelightHelpers;
 import frc.robot.sim.visionproducers.VisionSimInterface;
+import frc.robot.util.MathUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.BooleanSupplier;
+import java.util.function.DoubleSupplier;
 import java.util.function.Function;
 import java.util.List;
 import java.util.Optional;
@@ -38,6 +41,7 @@ public class SingleCamOdometry implements CamOdometryInterface {
     // no consumer needs the raw tag count.
     private boolean m_hasTargetLock = false;
     private boolean m_hasMultiTagLock = false;
+    private boolean m_isLatestMt2 = false;
     private double m_tx = 0.0;
     private List<Integer> m_targetList = Collections.emptyList();
     private int m_lastTarget = -1;
@@ -49,16 +53,26 @@ public class SingleCamOdometry implements CamOdometryInterface {
     // Samples the drivetrain's historical pose at a given FPGA timestamp (seconds)
     private final Function<Double, Optional<Pose2d>> m_poseSampler;
 
+    // Supplies the robot's current heading (degrees, WPILib blue-alliance frame) for MegaTag2
+    private final DoubleSupplier m_yawDegreesSupplier;
+
+    // Whether to request and prefer MegaTag2 pose estimates.
+    private final boolean m_supportMegatag2;
+
     /** Constructor. */
     public SingleCamOdometry(
         String limelightName,
         Transform3d robotToCam,
         VisionSimInterface.EstimateConsumer poseConsumer,
-        Function<Double, Optional<Pose2d>> poseSampler) {
+        Function<Double, Optional<Pose2d>> poseSampler,
+        DoubleSupplier yawDegreesSupplier,
+        boolean supportMegatag2) {
 
         m_estConsumer = poseConsumer;
         m_limelightName = limelightName;
         m_poseSampler = poseSampler;
+        m_yawDegreesSupplier = yawDegreesSupplier;
+        m_supportMegatag2 = supportMegatag2;
 
         setCameraPoseRobotSpace(m_limelightName, robotToCam);
     }
@@ -138,16 +152,18 @@ public class SingleCamOdometry implements CamOdometryInterface {
         m_curConfidenceScore = 0.0;
         m_hasTargetLock = false;
         m_hasMultiTagLock = false;
+        m_isLatestMt2 = false;
         m_tx = 0.0;
         m_targetList = Collections.emptyList();
         m_latestVisionError = Optional.empty();
     }
 
     private void setResults(double confidenceScore, int numLockedTags,
-                            LimelightHelpers.RawFiducial[] rawFiducials) {
+                            LimelightHelpers.RawFiducial[] rawFiducials, boolean isMegaTag2) {
         m_curConfidenceScore = confidenceScore;
         m_hasTargetLock = numLockedTags > 0;
         m_hasMultiTagLock = numLockedTags > 1;
+        m_isLatestMt2 = isMegaTag2 && numLockedTags > 0;
 
         // Horizontal offset to primary target (degrees)
         m_tx = LimelightHelpers.getTX(m_limelightName);
@@ -200,22 +216,35 @@ public class SingleCamOdometry implements CamOdometryInterface {
         System.out.println(sb.toString());
     }
 
+    @Override
+    public void setRobotOrientation() {
+        LimelightHelpers.SetRobotOrientation(
+            m_limelightName, m_yawDegreesSupplier.getAsDouble(), 0, 0, 0, 0, 0);
+    }
+
+    @Override
+    public void setRobotOrientation_NoFlush() {
+        LimelightHelpers.SetRobotOrientation_NoFlush(
+            m_limelightName, m_yawDegreesSupplier.getAsDouble(), 0, 0, 0, 0, 0);
+    }
+
     private void addVisionMeasurementV1() {
-        LimelightHelpers.PoseEstimate mt1 =
-            LimelightHelpers.getBotPoseEstimate_wpiBlue(m_limelightName);
+        LimelightHelpers.PoseEstimate mt1 = sanitizePoseEstimate(
+            LimelightHelpers.getBotPoseEstimate_wpiBlue(m_limelightName));
+        LimelightHelpers.PoseEstimate mt2 = m_supportMegatag2
+            ? sanitizePoseEstimate(LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(m_limelightName))
+            : null;
 
-        // Limelighthelpers 2026.1 no longer returns null when no targets are visible.
-        // So need to sanitize mt1 value so mt1 == null is still "no targets".
-        if (mt1 == null || mt1.tagCount == 0) {
-            mt1 = null;
-        }
+        // Pick the better estimate: more tags wins; on a tie, closer average distance wins;
+        // on a tie in both, prefer MT2 for its gyro-fused rotation stability.
+        LimelightHelpers.PoseEstimate poseEstimate = pickBestEstimate(mt1, mt2);
 
-        // printDebugLimelightInfo(mt1);
+        // printDebugLimelightInfo(poseEstimate);
 
         // Save the latest vision estimate so that it can be queried
-        m_latestVisPose = Optional.ofNullable(mt1).map(est -> est.pose);
+        m_latestVisPose = Optional.ofNullable(poseEstimate).map(est -> est.pose);
 
-        if (mt1 == null || mt1.tagCount == 0) {
+        if (poseEstimate == null || poseEstimate.tagCount == 0) {
             // In simulation, limelight may not be present until a few cycles of periodic, since we
             // populate it via NetworkTables later.
             clearResults();
@@ -223,33 +252,36 @@ public class SingleCamOdometry implements CamOdometryInterface {
         }
 
         // Skip if this is the same data we already processed
-        if (mt1.timestampSeconds == m_lastTimestamp) {
+        if (poseEstimate.timestampSeconds == m_lastTimestamp) {
             return;
         }
-        m_lastTimestamp = mt1.timestampSeconds;
+        m_lastTimestamp = poseEstimate.timestampSeconds;
 
         // We track how far-off this vision estimate is, using the ACTUAL pose in the past
         // of where the robot was when the camera image was snapped.
-        m_latestVisionError = calcVisionErrorAtSnapTime(mt1.pose, mt1.timestampSeconds);
+        m_latestVisionError =
+            calcVisionErrorAtSnapTime(poseEstimate.pose, poseEstimate.timestampSeconds);
 
         // Update std devs based on tag count and distance.  And confidence score.
-        m_curStdDevs = calculateEstimationStdDevs(mt1);
+        m_curStdDevs = calculateEstimationStdDevs(poseEstimate);
         m_curConfidenceScore = getConfidenceScore(m_curStdDevs);
 
-        if (mt1.tagCount == 1 && mt1.rawFiducials.length == 1) {
-            if (mt1.rawFiducials[0].ambiguity > 0.7) {
-                setResults(m_curConfidenceScore, 0, null);
+        // Ambiguity only matters for MegaTag1 (pure visual PnP); MT2 resolves ambiguity
+        // using the gyro heading, so this check must not apply to MT2 estimates.
+        if (!poseEstimate.isMegaTag2 && poseEstimate.tagCount == 1 && poseEstimate.rawFiducials.length == 1) {
+            if (poseEstimate.rawFiducials[0].ambiguity > 0.7) {
+                setResults(m_curConfidenceScore, 0, null, false);
                 return;
             }
         }
 
         // Check if std devs indicate rejection
         if (m_curStdDevs.get(0, 0) == Double.MAX_VALUE) {
-            setResults(m_curConfidenceScore, 0, null);
+            setResults(m_curConfidenceScore, 0, null, false);
             return;
         }
 
-        setResults(m_curConfidenceScore, mt1.tagCount, mt1.rawFiducials);
+        setResults(m_curConfidenceScore, poseEstimate.tagCount, poseEstimate.rawFiducials, poseEstimate.isMegaTag2);
 
         // Skip injecting vision measurements if vision is disabled
         if (!m_visionEnabledSupplier.getAsBoolean()) {
@@ -258,14 +290,49 @@ public class SingleCamOdometry implements CamOdometryInterface {
 
         // Inject into vision Kalman filter if robot is motionless and we have multi-tag
         if (m_visionKalmanFilter != null && m_isMotionlessSupplier != null) {
-            if (m_isMotionlessSupplier.getAsBoolean() && mt1.tagCount >= 2) {
-                m_visionKalmanFilter.injectVisionMeasurement(mt1.pose, mt1.tagCount);
+            if (m_isMotionlessSupplier.getAsBoolean() && poseEstimate.tagCount >= 2) {
+                m_visionKalmanFilter.injectVisionMeasurement(
+                    poseEstimate.pose, poseEstimate.tagCount);
             }
         }
 
         if (m_estConsumer != null) {
-            m_estConsumer.accept(mt1.pose, mt1.timestampSeconds, m_curStdDevs);
+            m_estConsumer.accept(
+                poseEstimate.pose, poseEstimate.timestampSeconds, m_curStdDevs);
         }
+    }
+
+    private LimelightHelpers.PoseEstimate sanitizePoseEstimate(
+            LimelightHelpers.PoseEstimate poseEstimate) {
+        // LimelightHelpers 2026.1 no longer returns null when no targets are visible.
+        if (poseEstimate == null || poseEstimate.tagCount == 0) {
+            return null;
+        }
+        return poseEstimate;
+    }
+
+    /**
+     * Picks the better of two pose estimates. More tags wins; on a tie, closer
+     * average tag distance wins (with MT2 getting a distance advantage since its
+     * gyro-fused rotation is more reliable at similar range); if still tied,
+     * prefer MT2 for gyro-fused stability. Either or both may be null.
+     */
+    static LimelightHelpers.PoseEstimate pickBestEstimate(
+            LimelightHelpers.PoseEstimate a,
+            LimelightHelpers.PoseEstimate b) {
+        if (a == null) return b;
+        if (b == null) return a;
+        if (a.tagCount != b.tagCount) {
+            return a.tagCount > b.tagCount ? a : b;
+        }
+        // Give MT2 a distance advantage by penalizing non-MT2 estimates, so values never go negative.
+        double distA = a.avgTagDist + (a.isMegaTag2 ? 0.0 : VisionConstants.kMt2DistanceAdvantageMeter);
+        double distB = b.avgTagDist + (b.isMegaTag2 ? 0.0 : VisionConstants.kMt2DistanceAdvantageMeter);
+        if (!MathUtils.approxEqual(distA, distB)) {
+            return distA < distB ? a : b;
+        }
+        // All else equal, prefer MT2 for gyro-fused rotation stability.
+        return b.isMegaTag2 ? b : a;
     }
 
     /**
@@ -292,11 +359,21 @@ public class SingleCamOdometry implements CamOdometryInterface {
             estStdDevs = kMultiTagStdDevs;
         }
 
-        // Increase std devs based on (average) distance
+        // Increase std devs based on (average) distance.
+        // Single-tag poses become unreliable past 4 m regardless of MT1 or MT2 — the gyro
+        // fusion in MT2 only resolves rotational ambiguity, not translational accuracy at
+        // long range. Reject single-tag estimates beyond 4 m for both pipelines.
         if (numTags == 1 && avgDist > 4) {
             return VecBuilder.fill(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
         }
-        return estStdDevs.times(1 + (avgDist * avgDist / 30));
+        Matrix<N3, N1> result = estStdDevs.times(1 + (avgDist * avgDist / 30));
+        if (poseEstimate.isMegaTag2) {
+            // MT2's reported rotation is the gyro heading reflected back — it carries no new
+            // rotational information, so we set theta std dev to a very large value so the
+            // pose estimator ignores the rotational component of this measurement.
+            return VecBuilder.fill(result.get(0, 0), result.get(1, 0), 9999999.0);
+        }
+        return result;
     }
 
     /**
@@ -345,6 +422,11 @@ public class SingleCamOdometry implements CamOdometryInterface {
     @Override
     public boolean hasMultiTagLock() {
         return m_hasMultiTagLock;
+    }
+
+    @Override
+    public boolean isLatestMt2() {
+        return m_isLatestMt2;
     }
 
     @Override

--- a/src/test/java/frc/robot/visutils/TestSingleCamOdometry.java
+++ b/src/test/java/frc/robot/visutils/TestSingleCamOdometry.java
@@ -81,7 +81,8 @@ class TestSingleCamOdometry {
         m_kalmanFilter = Mockito.mock(VisionKalmanFilter.class);
 
         // Identity transform — no rotation or translation from robot to camera.
-        m_cam = new SingleCamOdometry(CAM_NAME, new Transform3d(), consumer, null);
+        // Default test camera has MT2 disabled (most tests don't need it).
+        m_cam = new SingleCamOdometry(CAM_NAME, new Transform3d(), consumer, null, () -> 0.0, false);
     }
 
     @AfterEach
@@ -116,6 +117,161 @@ class TestSingleCamOdometry {
 
     /** Representative pose used across several tests. */
     private static final Pose2d POSE_A = new Pose2d(3.0, 2.0, Rotation2d.kZero);
+    private static final Pose2d POSE_B = new Pose2d(6.0, 1.0, Rotation2d.kPi);
+
+    // ------------------------------------------------------------------
+    // 0. MegaTag preference/fallback
+    // ------------------------------------------------------------------
+
+    /** Helper to create a camera with an explicit MT2 flag. */
+    private SingleCamOdometry createCamWithMt2(boolean supportMegatag2) {
+        VisionSimInterface.EstimateConsumer consumer =
+            (pose, ts, stdDevs) -> {
+                m_lastConsumedPose = pose;
+                m_consumeCallCount++;
+            };
+        return new SingleCamOdometry(CAM_NAME, new Transform3d(), consumer, null, () -> 0.0, supportMegatag2);
+    }
+
+    @Test
+    void periodic_megatag2Enabled_mt2MoreTags_prefersMt2() {
+        SingleCamOdometry cam = createCamWithMt2(true);
+        PoseEstimate mt1 = singleTagEstimate(POSE_A, 2.0, 1.0, 0.0);
+        PoseEstimate mt2 = new PoseEstimate(
+            POSE_B, 1.0, 0.0, 2, 0.0, 2.0, 0.0,
+            new RawFiducial[]{
+                new RawFiducial(1, 0, 0, 0, 2.0, 2.0, 0.1),
+                new RawFiducial(2, 0, 0, 0, 2.0, 2.0, 0.1)
+            },
+            true);
+
+        m_limelightMock.when(() -> LimelightHelpers.getBotPoseEstimate_wpiBlue(CAM_NAME))
+            .thenReturn(mt1);
+        m_limelightMock.when(() -> LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(CAM_NAME))
+            .thenReturn(mt2);
+
+        cam.periodic();
+
+        assertEquals(POSE_B, cam.getEstimatedPose().orElseThrow());
+        assertEquals(POSE_B, m_lastConsumedPose);
+        assertTrue(cam.hasMultiTagLock());
+        assertTrue(cam.isLatestMt2());
+    }
+
+    @Test
+    void periodic_megatag2Enabled_mt1MoreTags_prefersMt1() {
+        SingleCamOdometry cam = createCamWithMt2(true);
+        // MT1 sees 3 tags at 2m
+        RawFiducial f1 = new RawFiducial(1, 0, 0, 0, 2.0, 2.0, 0.1);
+        RawFiducial f2 = new RawFiducial(2, 0, 0, 0, 2.0, 2.0, 0.1);
+        RawFiducial f3 = new RawFiducial(3, 0, 0, 0, 2.0, 2.0, 0.1);
+        PoseEstimate mt1 = new PoseEstimate(
+            POSE_A, 1.0, 0.0, 3, 0.0, 2.0, 0.0,
+            new RawFiducial[]{f1, f2, f3}, false);
+        // MT2 sees 1 tag at 5m
+        PoseEstimate mt2 = new PoseEstimate(
+            POSE_B, 1.0, 0.0, 1, 0.0, 5.0, 0.0,
+            new RawFiducial[]{ new RawFiducial(4, 0, 0, 0, 5.0, 5.0, 0.0) },
+            true);
+
+        m_limelightMock.when(() -> LimelightHelpers.getBotPoseEstimate_wpiBlue(CAM_NAME))
+            .thenReturn(mt1);
+        m_limelightMock.when(() -> LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(CAM_NAME))
+            .thenReturn(mt2);
+
+        cam.periodic();
+
+        assertEquals(POSE_A, cam.getEstimatedPose().orElseThrow());
+        assertEquals(POSE_A, m_lastConsumedPose);
+        assertTrue(cam.hasMultiTagLock());
+        assertFalse(cam.isLatestMt2());
+    }
+
+    @Test
+    void periodic_megatag2Enabled_sameTagCount_mt1MuchCloser_prefersMt1() {
+        SingleCamOdometry cam = createCamWithMt2(true);
+        // Both see 1 tag; MT1 at 2m, MT2 at 3.5m — gap exceeds the MT2 distance advantage
+        PoseEstimate mt1 = singleTagEstimate(POSE_A, 2.0, 1.0, 0.0);
+        PoseEstimate mt2 = new PoseEstimate(
+            POSE_B, 1.0, 0.0, 1, 0.0, 3.5, 0.0,
+            new RawFiducial[]{ new RawFiducial(7, 0, 0, 0, 3.5, 3.5, 0.0) },
+            true);
+
+        m_limelightMock.when(() -> LimelightHelpers.getBotPoseEstimate_wpiBlue(CAM_NAME))
+            .thenReturn(mt1);
+        m_limelightMock.when(() -> LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(CAM_NAME))
+            .thenReturn(mt2);
+
+        cam.periodic();
+
+        assertEquals(POSE_A, cam.getEstimatedPose().orElseThrow());
+        assertFalse(cam.isLatestMt2());
+    }
+
+    @Test
+    void periodic_megatag2Enabled_sameTagCount_mt2SlightlyFarther_prefersMt2() {
+        SingleCamOdometry cam = createCamWithMt2(true);
+        // Both see 1 tag; MT1 at 2.0m, MT2 at 2.3m — within the 0.5m MT2 advantage
+        PoseEstimate mt1 = singleTagEstimate(POSE_A, 2.0, 1.0, 0.0);
+        PoseEstimate mt2 = new PoseEstimate(
+            POSE_B, 1.0, 0.0, 1, 0.0, 2.3, 0.0,
+            new RawFiducial[]{ new RawFiducial(7, 0, 0, 0, 2.3, 2.3, 0.0) },
+            true);
+
+        m_limelightMock.when(() -> LimelightHelpers.getBotPoseEstimate_wpiBlue(CAM_NAME))
+            .thenReturn(mt1);
+        m_limelightMock.when(() -> LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(CAM_NAME))
+            .thenReturn(mt2);
+
+        cam.periodic();
+
+        assertEquals(POSE_B, cam.getEstimatedPose().orElseThrow());
+        assertTrue(cam.isLatestMt2());
+    }
+
+    @Test
+    void periodic_megatag2Disabled_ignoresMegaTag2_usesMegaTag1() {
+        SingleCamOdometry cam = createCamWithMt2(false);
+        PoseEstimate mt1 = singleTagEstimate(POSE_A, 2.0, 1.0, 0.0);
+        PoseEstimate mt2 = new PoseEstimate(
+            POSE_B, 1.0, 0.0, 2, 0.0, 2.0, 0.0,
+            new RawFiducial[]{
+                new RawFiducial(1, 0, 0, 0, 2.0, 2.0, 0.1),
+                new RawFiducial(2, 0, 0, 0, 2.0, 2.0, 0.1)
+            },
+            true);
+
+        m_limelightMock.when(() -> LimelightHelpers.getBotPoseEstimate_wpiBlue(CAM_NAME))
+            .thenReturn(mt1);
+        // MT2 is available but flag is off — should never be queried.
+        m_limelightMock.when(() -> LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(CAM_NAME))
+            .thenReturn(mt2);
+
+        cam.periodic();
+
+        assertEquals(POSE_A, cam.getEstimatedPose().orElseThrow());
+        assertEquals(POSE_A, m_lastConsumedPose);
+        assertTrue(cam.hasTargetLock());
+        assertFalse(cam.isLatestMt2());
+    }
+
+    @Test
+    void periodic_megatag2Enabled_noMt2Available_fallsBackToMegaTag1() {
+        SingleCamOdometry cam = createCamWithMt2(true);
+        PoseEstimate mt1 = singleTagEstimate(POSE_A, 2.0, 1.0, 0.0);
+
+        m_limelightMock.when(() -> LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(CAM_NAME))
+            .thenReturn(null);
+        m_limelightMock.when(() -> LimelightHelpers.getBotPoseEstimate_wpiBlue(CAM_NAME))
+            .thenReturn(mt1);
+
+        cam.periodic();
+
+        assertEquals(POSE_A, cam.getEstimatedPose().orElseThrow());
+        assertEquals(POSE_A, m_lastConsumedPose);
+        assertTrue(cam.hasTargetLock());
+        assertFalse(cam.isLatestMt2());
+    }
 
     // ------------------------------------------------------------------
     // 1. No-target path
@@ -215,6 +371,28 @@ class TestSingleCamOdometry {
 
         assertFalse(m_cam.hasTargetLock());
         assertEquals(0.0, m_cam.getConfidenceScore());
+    }
+
+    /**
+     * MT2 single-tag beyond 4 m must also be rejected — gyro fusion only resolves
+     * rotational ambiguity, not translational accuracy at long range.
+     */
+    @Test
+    void periodic_mt2SingleTag_beyondFourMeters_isRejected() {
+        SingleCamOdometry cam = createCamWithMt2(true);
+        PoseEstimate mt2 = new PoseEstimate(
+            POSE_A, 1.0, 0.0, 1, 0.0, 5.0, 0.0,
+            new RawFiducial[]{ new RawFiducial(7, 0, 0, 0, 5.0, 5.0, 0.0) },
+            true);
+        m_limelightMock.when(() -> LimelightHelpers.getBotPoseEstimate_wpiBlue(CAM_NAME))
+            .thenReturn(null);
+        m_limelightMock.when(() -> LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(CAM_NAME))
+            .thenReturn(mt2);
+
+        cam.periodic();
+
+        assertFalse(cam.hasTargetLock());
+        assertEquals(0.0, cam.getConfidenceScore());
     }
 
     /**


### PR DESCRIPTION
Add gyro heading for Megatag2

Megatag2 does not discard ambiguity >0.7

Trust Megatag2 x and y much higher

Perf fix to reduce network flushing

Show is mt2 on dashboard

Show whether MT2

For simulation only dont use megatag2
Cleanup Elastic

Optionally publish Metatag2 to NetworkTables in sim

Optionally support Megatag2

Fix unit tests

Ignore Mt2 tags >4 meters

Use Megatag1 if it happens to be better