### PR TITLE
All vision config is now per-robot

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -217,19 +217,6 @@ public final class Constants {
     // To upload fmap:
     // curl -X POST http://10.90.36.15:5807/upload-fieldmap -H "Content-Type: application/json" --data-binary @FRC2026_ANDYMARK.fmap
     public static final class VisionConstants {
-        /** Default value for the VisionEnabled toggle (true = vision on). */
-        public static final boolean kVisionEnabledDefault = false;
-
-        /** When false, MegaTag2 pose estimates are never requested or used. */
-        // $TODO2 - Enable after testing
-        public static final boolean kSupportMegatag2 = false;
-
-        /**
-         * When true, vision pose estimates are automatically injected into the drivetrain pose estimator;
-         * when false, they must be manually consumed from the dashboard.
-         * */
-        public static final boolean kAutoVisionInjectionEnabled = true;
-
         /**
          * Distance advantage (meters) given to MegaTag2 when comparing estimates.
          * MT2 is preferred over MT1 if its avgTagDist is within this margin of MT1's,

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -23,7 +23,6 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Direction;
 import frc.robot.Constants.ClimberConstants;
 import frc.robot.Constants.DriveConstants;
-import frc.robot.Constants.VisionConstants;
 import frc.robot.botconfig.BotConfigInterface;
 import frc.robot.botconfig.RobotIdentity;
 import frc.robot.commands.FullAutoClimbCommand;
@@ -131,6 +130,7 @@ public class RobotContainer {
     public final CommandSwerveDrivetrain drivetrain = m_configInterface.createDrivetrain();
 
     public final BasicInfoDashboard basicInfoDashboard = new BasicInfoDashboard(
+        m_configInterface,
         drivetrain,
         m_configInterface.getCameras().stream()
             .map(c -> c.cameraName)
@@ -260,9 +260,7 @@ public class RobotContainer {
             () -> drivetrain.getState().Pose.getRotation().getDegrees(),
             basicInfoDashboard,
             m_visionKalmanFilter,
-            m_motionlessTracker,
-            VisionConstants.kSupportMegatag2,
-            VisionConstants.kAutoVisionInjectionEnabled);
+            m_motionlessTracker);
     }
 
     /** Registers named commands for PathPlanner */

--- a/src/main/java/frc/robot/botconfig/BotConfigInterface.java
+++ b/src/main/java/frc/robot/botconfig/BotConfigInterface.java
@@ -143,6 +143,15 @@ public interface BotConfigInterface {
      *
      ************************************************************************************/
 
+    /** Default value for the VisionEnabled dashboard toggle (true = vision on by default). */
+    boolean isVisionEnabledDefault();
+
+    /** When false, MegaTag2 pose estimates are never requested or used. */
+    boolean isMegaTag2Supported();
+
+    /** When true, vision pose estimates are automatically injected into the drivetrain pose estimator. */
+    boolean isAutoVisionInjectionEnabled();
+
     /** Camera configurations for the real robot. */
     List<CameraInfo> getCameras();
 

--- a/src/main/java/frc/robot/botconfig/CompConfig.java
+++ b/src/main/java/frc/robot/botconfig/CompConfig.java
@@ -143,6 +143,21 @@ public class CompConfig implements BotConfigInterface {
      *
      ************************************************************************************/
 
+    @Override
+    public boolean isVisionEnabledDefault() {
+        return false;
+    }
+
+    @Override
+    public boolean isMegaTag2Supported() {
+        return false; // $TODO2 - Enable after testing
+    }
+
+    @Override
+    public boolean isAutoVisionInjectionEnabled() {
+        return true;
+    }
+
     private final List<CameraInfo> m_cameras = List.of(
         new CameraInfo("limelight", new Transform3d(
             new Translation3d(

--- a/src/main/java/frc/robot/botconfig/PancakeConfig.java
+++ b/src/main/java/frc/robot/botconfig/PancakeConfig.java
@@ -142,6 +142,21 @@ public class PancakeConfig implements BotConfigInterface {
      *
      ************************************************************************************/
 
+    @Override
+    public boolean isVisionEnabledDefault() {
+        return true;
+    }
+
+    @Override
+    public boolean isMegaTag2Supported() {
+        return false; // $TODO2 - Enable after testing
+    }
+
+    @Override
+    public boolean isAutoVisionInjectionEnabled() {
+        return true;
+    }
+
     private final List<CameraInfo> m_cameras = List.of(
         new CameraInfo("limelight-fixedii", new Transform3d(
             new Translation3d(

--- a/src/main/java/frc/robot/visutils/BasicInfoDashboard.java
+++ b/src/main/java/frc/robot/visutils/BasicInfoDashboard.java
@@ -17,8 +17,7 @@ import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.StringPublisher;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
-import frc.robot.Constants;
-import frc.robot.Constants.VisionConstants;
+import frc.robot.botconfig.BotConfigInterface;
 import frc.robot.visutils.VisionKalmanFilter;
 
 import java.util.List;
@@ -58,8 +57,8 @@ public class BasicInfoDashboard {
     private final DoublePublisher m_visErrorMultiTagCentimeters = m_basicInfoTable.getDoubleTopic("VisErrorMultiTagCentimeters").publish();
 
     /** Bidirectional toggle for enabling/disabling vision measurement injection. */
-    private final BooleanEntry m_visionEnabled =
-        m_basicInfoTable.getBooleanTopic("VisionEnabled").getEntry(Constants.VisionConstants.kVisionEnabledDefault);
+    private final BooleanEntry m_visionEnabled;
+    private final BotConfigInterface m_configInterface;
 
     /* Vision Kalman filter outputs */
     private final DoubleArrayPublisher m_visionKalmanPose =
@@ -116,12 +115,19 @@ public class BasicInfoDashboard {
     /**
      * Constructs a BasicInfoDashboard.
      *
-     * @param drivetrain  The swerve drivetrain to get info from
-     * @param cameraNames Names of all Limelight cameras to monitor
+     * @param drivetrain      The swerve drivetrain to get info from
+     * @param cameraNames     Names of all Limelight cameras to monitor
+     * @param configInterface Bot configuration (vision defaults, etc.)
      */
-    public BasicInfoDashboard(SwerveDrivetrain<TalonFX, TalonFX, CANcoder> drivetrain, List<String> cameraNames) {
+    public BasicInfoDashboard(
+        BotConfigInterface configInterface,
+        SwerveDrivetrain<TalonFX, TalonFX, CANcoder> drivetrain,
+        List<String> cameraNames) {
+
         m_drivetrain = drivetrain;
         m_pigeon = drivetrain.getPigeon2();
+        m_configInterface = configInterface;
+        m_visionEnabled = m_basicInfoTable.getBooleanTopic("VisionEnabled").getEntry(m_configInterface.isVisionEnabledDefault());
 
         NetworkTable cameraTable = m_basicInfoTable.getSubTable("Camera");
         m_cameraMonitors = new java.util.ArrayList<>();
@@ -133,7 +139,7 @@ public class BasicInfoDashboard {
         }
 
         // Publish the default value so the toggle appears in Elastic immediately.
-        m_visionEnabled.set(Constants.VisionConstants.kVisionEnabledDefault);
+        m_visionEnabled.set(m_configInterface.isVisionEnabledDefault());
     }
 
     /**
@@ -146,7 +152,7 @@ public class BasicInfoDashboard {
         if (m_forceDisableVision) {
             return false;
         }
-        return m_visionEnabled.get(Constants.VisionConstants.kVisionEnabledDefault);
+        return m_visionEnabled.get(m_configInterface.isVisionEnabledDefault());
     }
 
     /**

--- a/src/main/java/frc/robot/visutils/CamOdometryInterface.java
+++ b/src/main/java/frc/robot/visutils/CamOdometryInterface.java
@@ -78,12 +78,6 @@ public interface CamOdometryInterface {
      */
     void enableVision(boolean enabled);
 
-    // $TODO2 - Get rid of this
-    /**
-     * Enable/Disable MegaTag2 pose estimation support.
-     */
-    void enableMegatag2(boolean enabled);
-
     /**
      * Sets the dependencies needed for vision processing.
      *

--- a/src/main/java/frc/robot/visutils/MultiCamOdometry.java
+++ b/src/main/java/frc/robot/visutils/MultiCamOdometry.java
@@ -13,8 +13,8 @@ import java.util.function.BooleanSupplier;
 
 /** Reads from multiple limelight cameras. */
 public class MultiCamOdometry implements CamOdometryInterface {
-    private boolean m_megaTag2Enabled;
-    private boolean m_autoVisionInjectionEnabled;
+    private final boolean m_megaTag2Enabled;
+    private final boolean m_autoVisionInjectionEnabled;
 
     private final List<CamOdometryInterface> m_cameras;
     private final PerCycleState m_perCycleState = new PerCycleState();
@@ -109,15 +109,6 @@ public class MultiCamOdometry implements CamOdometryInterface {
     @Override
     public void enableVision(boolean enabled) {
         throw new UnsupportedOperationException("Vision enabling/disabling is not supported at the MultiCamOdometry level; enable/disable the entire wrapper instead.");
-    }
-
-    @Override
-    public void enableMegatag2(boolean enabled) {
-        m_megaTag2Enabled = enabled;
-
-        for (CamOdometryInterface cam : m_cameras) {
-            cam.enableMegatag2(enabled);
-        }
     }
 
     @Override

--- a/src/main/java/frc/robot/visutils/MultiCamOdometryFactory.java
+++ b/src/main/java/frc/robot/visutils/MultiCamOdometryFactory.java
@@ -4,7 +4,6 @@ import edu.wpi.first.math.geometry.Pose2d;
 import frc.robot.botconfig.BotConfigInterface;
 import frc.robot.botconfig.BotConfigInterface.CameraInfo;
 import frc.robot.sim.visionproducers.VisionSimInterface;
-import frc.robot.Constants.VisionConstants;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -39,9 +38,10 @@ public class MultiCamOdometryFactory {
             DoubleSupplier yawDegreesSupplier,
             BasicInfoDashboard basicInfoDashboard,
             VisionKalmanFilter visionKalmanFilter,
-            MotionlessTracker motionlessTracker,
-            boolean megaTag2Enabled,
-            boolean autoVisionInjectionEnabled) {
+            MotionlessTracker motionlessTracker) {
+
+        boolean megaTag2Enabled = configInterface.isMegaTag2Supported();
+        boolean autoVisionInjectionEnabled = configInterface.isAutoVisionInjectionEnabled();
 
         List<CamOdometryInterface> cameras = new ArrayList<>();
         for (CameraInfo camInfo : configInterface.getCameras()) {
@@ -61,7 +61,7 @@ public class MultiCamOdometryFactory {
             autoVisionInjectionEnabled);
 
         MultiCamOdometryWrapper wrapper =
-                new MultiCamOdometryWrapper(multiCam, VisionConstants.kVisionEnabledDefault);
+                new MultiCamOdometryWrapper(multiCam, configInterface.isVisionEnabledDefault());
 
         wrapper.setVisionDependenciesOnCamera(
             visionKalmanFilter,

--- a/src/main/java/frc/robot/visutils/MultiCamOdometryWrapper.java
+++ b/src/main/java/frc/robot/visutils/MultiCamOdometryWrapper.java
@@ -12,10 +12,6 @@ import java.util.function.BooleanSupplier;
  * <p>When enabled, all calls are delegated to {@code m_multiCamReal}. When disabled, all calls are
  * delegated to {@code m_multiCamNoop}, which returns safe default values and performs no side
  * effects.
- *
- * <p>Configuration calls ({@link #setVisionDependenciesOnCamera} and {@link #enableMegatag2}) are
- * always forwarded to the real camera regardless of the current enable state, so that the real
- * camera is fully configured when re-enabled.
  */
 public class MultiCamOdometryWrapper implements CamOdometryInterface {
     private final CamOdometryInterface m_multiCamReal;
@@ -105,15 +101,6 @@ public class MultiCamOdometryWrapper implements CamOdometryInterface {
     @Override
     public void enableVision(boolean enabled) {
         m_enabled = enabled;
-    }
-
-    /**
-     * Always forwarded to the real camera — MT2 configuration is independent of enable state so
-     * that the real camera is correctly configured when re-enabled.
-     */
-    @Override
-    public void enableMegatag2(boolean enabled) {
-        m_multiCamReal.enableMegatag2(enabled);
     }
 
     /**

--- a/src/main/java/frc/robot/visutils/NoOpCamOdometry.java
+++ b/src/main/java/frc/robot/visutils/NoOpCamOdometry.java
@@ -68,9 +68,6 @@ class NoOpCamOdometry implements CamOdometryInterface {
     public void enableVision(boolean enabled) {}
 
     @Override
-    public void enableMegatag2(boolean enabled) {}
-
-    @Override
     public void setVisionDependenciesOnCamera(
             VisionKalmanFilter filter,
             BooleanSupplier isMotionlessSupplier) {}

--- a/src/main/java/frc/robot/visutils/SingleCamOdometry.java
+++ b/src/main/java/frc/robot/visutils/SingleCamOdometry.java
@@ -12,6 +12,7 @@ import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import com.ctre.phoenix6.Utils;
 
+import edu.wpi.first.wpilibj.DriverStation;
 import frc.robot.Constants;
 import frc.robot.Constants.VisionConstants;
 import frc.robot.LimelightHelpers;
@@ -31,10 +32,8 @@ import java.util.stream.Collectors;
  * Limelight-based odometry measurement source.
  */
 public class SingleCamOdometry implements CamOdometryInterface {
-    // These two enable-values are initialized here, but can be dynamically updated
-    // using the enableVision() and enableMegatag2() methods.
-    private boolean m_megaTag2Enabled;
-    private boolean m_autoVisionInjectionEnabled;
+    private final boolean m_megaTag2Enabled;
+    private final boolean m_autoVisionInjectionEnabled;
 
     private final String m_limelightName;
     private VisionSimInterface.EstimateConsumer m_estConsumer;
@@ -153,11 +152,6 @@ public class SingleCamOdometry implements CamOdometryInterface {
     @Override
     public void enableVision(boolean enabled) {
         throw new UnsupportedOperationException("Vision enabling/disabling is not supported at the SingleCamOdometry level; enable/disable the entire wrapper instead.");
-    }
-
-    @Override
-    public void enableMegatag2(boolean enabled) {
-        m_megaTag2Enabled = enabled;
     }
 
     private void clearResults() {
@@ -311,18 +305,16 @@ public class SingleCamOdometry implements CamOdometryInterface {
 
         setResults(m_curConfidenceScore, poseEstimate.tagCount, poseEstimate.rawFiducials, poseEstimate.isMegaTag2);
 
-        // $TODO2 - We should ONLY inject vision measurements in AUTO.  Does that
-        // mean we neeed to move this to a autoPeriodic or something else?
-        // Only injecting vision measurements if vision is enabled
-        if (true) {
-
-            // Inject into vision Kalman filter if robot is motionless and we have multi-tag
-            if (m_visionKalmanFilter != null && m_isMotionlessSupplier != null) {
-                if (m_isMotionlessSupplier.getAsBoolean() && poseEstimate.tagCount >= 2) {
-                    m_visionKalmanFilter.injectVisionMeasurement(
-                        poseEstimate.pose, poseEstimate.tagCount);
-                }
+        // Inject into vision Kalman filter if robot is motionless and we have multi-tag
+        if (m_visionKalmanFilter != null && m_isMotionlessSupplier != null) {
+            if (m_isMotionlessSupplier.getAsBoolean() && poseEstimate.tagCount >= 2) {
+                m_visionKalmanFilter.injectVisionMeasurement(
+                    poseEstimate.pose, poseEstimate.tagCount);
             }
+        }
+
+        // $We should ONLY inject vision measurements in AUTO.
+        if (m_autoVisionInjectionEnabled && !DriverStation.isTeleopEnabled()) {
 
             if (m_estConsumer != null) {
                 m_estConsumer.accept(

--- a/src/test/java/frc/robot/visutils/TestMultiCamOdometryWrapper.java
+++ b/src/test/java/frc/robot/visutils/TestMultiCamOdometryWrapper.java
@@ -345,26 +345,6 @@ class TestMultiCamOdometryWrapper {
     // ------------------------------------------------------------------
 
     @Test
-    void enableMegatag2_alwaysForwardedToReal_whenEnabled() {
-        CamOdometryInterface real = newRealMock();
-        MultiCamOdometryWrapper wrapper = new MultiCamOdometryWrapper(real, true);
-
-        wrapper.enableMegatag2(false);
-
-        Mockito.verify(real).enableMegatag2(false);
-    }
-
-    @Test
-    void enableMegatag2_alwaysForwardedToReal_whenDisabled() {
-        CamOdometryInterface real = newRealMock();
-        MultiCamOdometryWrapper wrapper = new MultiCamOdometryWrapper(real, false);
-
-        wrapper.enableMegatag2(true);
-
-        Mockito.verify(real).enableMegatag2(true);
-    }
-
-    @Test
     void setVisionDependenciesOnCamera_alwaysForwardedToReal_whenEnabled() {
         CamOdometryInterface real = newRealMock();
         MultiCamOdometryWrapper wrapper = new MultiCamOdometryWrapper(real, true);
@@ -455,8 +435,6 @@ class TestMultiCamOdometryWrapper {
             noop.setRobotOrientation_NoFlush();
             noop.enableVision(true);
             noop.enableVision(false);
-            noop.enableMegatag2(true);
-            noop.enableMegatag2(false);
             noop.setVisionDependenciesOnCamera(null, null);
         });
     }


### PR DESCRIPTION
Only inject into drivetrain if not in Teleop

Part1 of moving vision config to per-bot config

Part2 of moving vision config to per-robot config